### PR TITLE
improvement: Connector research by application name now based on real application name

### DIFF
--- a/src/main/kotlin/org/ozwillo/dcimporter/model/BusinessAppConfiguration.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/model/BusinessAppConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 data class BusinessAppConfiguration(
     @Id val id: String? = null,
     val applicationName: String,
-    val originAppName: String,
+    val displayName: String,
     val baseUrl: String,
     val organizationSiret: String,
     val instanceId: String? = null,

--- a/src/main/kotlin/org/ozwillo/dcimporter/model/BusinessAppConfiguration.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/model/BusinessAppConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 data class BusinessAppConfiguration(
     @Id val id: String? = null,
     val applicationName: String,
+    val originAppName: String,
     val baseUrl: String,
     val organizationSiret: String,
     val instanceId: String? = null,

--- a/src/main/kotlin/org/ozwillo/dcimporter/repository/BusinessAppConfigurationRepository.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/repository/BusinessAppConfigurationRepository.kt
@@ -10,11 +10,11 @@ import reactor.core.publisher.Mono
 interface BusinessAppConfigurationRepository : ReactiveMongoRepository<BusinessAppConfiguration, String> {
     fun findByApplicationName(applicationName: String): Flux<BusinessAppConfiguration>
 
-    fun findByOriginAppNameIgnoreCaseContaining(
+    fun findByDisplayNameIgnoreCaseContaining(
         applicationName: String
     ): Flux<BusinessAppConfiguration>
 
-    fun findByOrganizationSiretAndOriginAppNameIgnoreCaseContaining(
+    fun findByOrganizationSiretAndDisplayNameIgnoreCaseContaining(
         siret: String,
         applicationName: String
     ): Flux<BusinessAppConfiguration>

--- a/src/main/kotlin/org/ozwillo/dcimporter/repository/BusinessAppConfigurationRepository.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/repository/BusinessAppConfigurationRepository.kt
@@ -10,11 +10,11 @@ import reactor.core.publisher.Mono
 interface BusinessAppConfigurationRepository : ReactiveMongoRepository<BusinessAppConfiguration, String> {
     fun findByApplicationName(applicationName: String): Flux<BusinessAppConfiguration>
 
-    fun findByApplicationNameIgnoreCaseContaining(
+    fun findByOriginAppNameIgnoreCaseContaining(
         applicationName: String
     ): Flux<BusinessAppConfiguration>
 
-    fun findByOrganizationSiretAndApplicationNameIgnoreCaseContaining(
+    fun findByOrganizationSiretAndOriginAppNameIgnoreCaseContaining(
         siret: String,
         applicationName: String
     ): Flux<BusinessAppConfiguration>

--- a/src/main/kotlin/org/ozwillo/dcimporter/service/ConnectorsService.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/service/ConnectorsService.kt
@@ -17,9 +17,9 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
 
     fun searchConnectors(siret: String, appName: String): Flux<BusinessAppConfiguration> {
         return when {
-            !siret.isEmpty() && !appName.isEmpty() -> this.getAllBySiretAndContainingOriginAppName(siret, appName)
+            !siret.isEmpty() && !appName.isEmpty() -> this.getAllBySiretAndContainingDisplayName(siret, appName)
             !siret.isEmpty() && appName.isEmpty() -> this.getAllBySiret(siret)
-            siret.isEmpty() && !appName.isEmpty() -> this.getAllContainingOriginAppName(appName)
+            siret.isEmpty() && !appName.isEmpty() -> this.getAllContainingDisplayName(appName)
             else -> this.getAll()
         }
     }
@@ -40,12 +40,12 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
         return businessAppConfigurationRepository.findByOrganizationSiret(siret)
     }
 
-    fun getAllContainingOriginAppName(appName: String): Flux<BusinessAppConfiguration>{
-        return businessAppConfigurationRepository.findByOriginAppNameIgnoreCaseContaining(appName)
+    fun getAllContainingDisplayName(appName: String): Flux<BusinessAppConfiguration>{
+        return businessAppConfigurationRepository.findByDisplayNameIgnoreCaseContaining(appName)
     }
 
-    fun getAllBySiretAndContainingOriginAppName(siret: String, appName: String): Flux<BusinessAppConfiguration> {
-        return businessAppConfigurationRepository.findByOrganizationSiretAndOriginAppNameIgnoreCaseContaining(siret, appName)
+    fun getAllBySiretAndContainingDisplayName(siret: String, appName: String): Flux<BusinessAppConfiguration> {
+        return businessAppConfigurationRepository.findByOrganizationSiretAndDisplayNameIgnoreCaseContaining(siret, appName)
     }
 
     fun create(siret: String, appName: String, businessAppConfiguration: BusinessAppConfiguration): Mono<HttpStatus> {
@@ -54,7 +54,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
             .defaultIfEmpty(
                 BusinessAppConfiguration(
                     applicationName = "",
-                    originAppName = "",
+                    displayName = "",
                     organizationSiret = siret,
                     baseUrl = businessAppConfiguration.baseUrl
                 )
@@ -69,7 +69,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
                             login = businessAppConfiguration.login,
                             password = businessAppConfiguration.password,
                             applicationName = appName,
-                            originAppName = businessAppConfiguration.originAppName,
+                            displayName = businessAppConfiguration.displayName,
                             secretOrToken = businessAppConfiguration.secretOrToken
                         )
                     ).subscribe()
@@ -103,7 +103,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
                                 login = businessAppConfiguration.login,
                                 password = businessAppConfiguration.password,
                                 applicationName = appName,
-                                originAppName = businessAppConfiguration.originAppName,
+                                displayName = businessAppConfiguration.displayName,
                                 secretOrToken = businessAppConfiguration.secretOrToken
                             )
                         ).subscribe()

--- a/src/main/kotlin/org/ozwillo/dcimporter/service/ConnectorsService.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/service/ConnectorsService.kt
@@ -17,9 +17,9 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
 
     fun searchConnectors(siret: String, appName: String): Flux<BusinessAppConfiguration> {
         return when {
-            !siret.isEmpty() && !appName.isEmpty() -> this.getAllBySiretAndContainingAppName(siret, appName)
+            !siret.isEmpty() && !appName.isEmpty() -> this.getAllBySiretAndContainingOriginAppName(siret, appName)
             !siret.isEmpty() && appName.isEmpty() -> this.getAllBySiret(siret)
-            siret.isEmpty() && !appName.isEmpty() -> this.getAllContainingAppName(appName)
+            siret.isEmpty() && !appName.isEmpty() -> this.getAllContainingOriginAppName(appName)
             else -> this.getAll()
         }
     }
@@ -40,12 +40,12 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
         return businessAppConfigurationRepository.findByOrganizationSiret(siret)
     }
 
-    fun getAllContainingAppName(appName: String): Flux<BusinessAppConfiguration>{
-        return businessAppConfigurationRepository.findByApplicationNameIgnoreCaseContaining(appName)
+    fun getAllContainingOriginAppName(appName: String): Flux<BusinessAppConfiguration>{
+        return businessAppConfigurationRepository.findByOriginAppNameIgnoreCaseContaining(appName)
     }
 
-    fun getAllBySiretAndContainingAppName(siret: String, appName: String): Flux<BusinessAppConfiguration> {
-        return businessAppConfigurationRepository.findByOrganizationSiretAndApplicationNameIgnoreCaseContaining(siret, appName)
+    fun getAllBySiretAndContainingOriginAppName(siret: String, appName: String): Flux<BusinessAppConfiguration> {
+        return businessAppConfigurationRepository.findByOrganizationSiretAndOriginAppNameIgnoreCaseContaining(siret, appName)
     }
 
     fun create(siret: String, appName: String, businessAppConfiguration: BusinessAppConfiguration): Mono<HttpStatus> {
@@ -54,6 +54,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
             .defaultIfEmpty(
                 BusinessAppConfiguration(
                     applicationName = "",
+                    originAppName = "",
                     organizationSiret = siret,
                     baseUrl = businessAppConfiguration.baseUrl
                 )
@@ -68,6 +69,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
                             login = businessAppConfiguration.login,
                             password = businessAppConfiguration.password,
                             applicationName = appName,
+                            originAppName = businessAppConfiguration.originAppName,
                             secretOrToken = businessAppConfiguration.secretOrToken
                         )
                     ).subscribe()
@@ -101,6 +103,7 @@ class ConnectorsService(private val businessAppConfigurationRepository: Business
                                 login = businessAppConfiguration.login,
                                 password = businessAppConfiguration.password,
                                 applicationName = appName,
+                                originAppName = businessAppConfiguration.originAppName,
                                 secretOrToken = businessAppConfiguration.secretOrToken
                             )
                         ).subscribe()

--- a/src/main/kotlin/org/ozwillo/dcimporter/web/ConnectorsHandler.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/web/ConnectorsHandler.kt
@@ -35,6 +35,7 @@ class ConnectorsHandler(private val connectorsService: ConnectorsService) {
                             BusinessAppConfiguration(
                                 id = connector.id,
                                 applicationName = connector.applicationName,
+                                originAppName = connector.originAppName,
                                 organizationSiret = connector.organizationSiret,
                                 baseUrl = connector.baseUrl)
                         }

--- a/src/main/kotlin/org/ozwillo/dcimporter/web/ConnectorsHandler.kt
+++ b/src/main/kotlin/org/ozwillo/dcimporter/web/ConnectorsHandler.kt
@@ -35,7 +35,7 @@ class ConnectorsHandler(private val connectorsService: ConnectorsService) {
                             BusinessAppConfiguration(
                                 id = connector.id,
                                 applicationName = connector.applicationName,
-                                originAppName = connector.originAppName,
+                                displayName = connector.displayName,
                                 organizationSiret = connector.organizationSiret,
                                 baseUrl = connector.baseUrl)
                         }

--- a/src/main/resources/public/src/views/ConnectorsManagement.vue
+++ b/src/main/resources/public/src/views/ConnectorsManagement.vue
@@ -38,7 +38,7 @@
                     </thead>
                     <tbody>
                         <tr v-for="connector in connectors">
-                            <td>{{connector.originAppName}}</td>
+                            <td>{{connector.displayName}}</td>
                             <td>{{findOrganizationNameInMap(connector.organizationSiret)}}</td>
                             <td>{{connector.organizationSiret}}</td>
                             <td>++</td>

--- a/src/main/resources/public/src/views/ConnectorsManagement.vue
+++ b/src/main/resources/public/src/views/ConnectorsManagement.vue
@@ -38,7 +38,7 @@
                     </thead>
                     <tbody>
                         <tr v-for="connector in connectors">
-                            <td>{{connector.applicationName}}</td>
+                            <td>{{connector.originAppName}}</td>
                             <td>{{findOrganizationNameInMap(connector.organizationSiret)}}</td>
                             <td>{{connector.organizationSiret}}</td>
                             <td>++</td>

--- a/src/test/kotlin/org/ozwillo/dcimporter/PostAndNotifyTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/PostAndNotifyTest.kt
@@ -43,7 +43,7 @@ class PostAndNotifyTest : AbstractIntegrationTests() {
         if (!optPublikConfiguration.isPresent) {
             val publikConfiguration = BusinessAppConfiguration(
                 baseUrl = "https://demarches-sve.test-demarches.sictiam.fr",
-                organizationSiret = "20003019500115", secretOrToken = "aSYZexOBIzl8", applicationName = "publik", originAppName = "Publik"
+                organizationSiret = "20003019500115", secretOrToken = "aSYZexOBIzl8", applicationName = "publik", displayName = "Publik"
             )
             businessAppConfigurationRepository.save(publikConfiguration).subscribe()
         }

--- a/src/test/kotlin/org/ozwillo/dcimporter/PostAndNotifyTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/PostAndNotifyTest.kt
@@ -43,7 +43,7 @@ class PostAndNotifyTest : AbstractIntegrationTests() {
         if (!optPublikConfiguration.isPresent) {
             val publikConfiguration = BusinessAppConfiguration(
                 baseUrl = "https://demarches-sve.test-demarches.sictiam.fr",
-                organizationSiret = "20003019500115", secretOrToken = "aSYZexOBIzl8", applicationName = "Publik"
+                organizationSiret = "20003019500115", secretOrToken = "aSYZexOBIzl8", applicationName = "publik", originAppName = "Publik"
             )
             businessAppConfigurationRepository.save(publikConfiguration).subscribe()
         }

--- a/src/test/kotlin/org/ozwillo/dcimporter/handler/MarchePublicHandlerTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/handler/MarchePublicHandlerTest.kt
@@ -76,7 +76,7 @@ class MarchePublicHandlerTest(@Autowired val restTemplate: TestRestTemplate) {
         )
         businessAppConfiguration = BusinessAppConfiguration(
             applicationName = MarcheSecuriseService.name,
-            originAppName = "Marchés Sécurisés",
+            displayName = "Marchés Sécurisés",
             baseUrl = "http://localhost:8089",
             organizationSiret = siret,
             instanceId = "pa",

--- a/src/test/kotlin/org/ozwillo/dcimporter/handler/MarchePublicHandlerTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/handler/MarchePublicHandlerTest.kt
@@ -76,6 +76,7 @@ class MarchePublicHandlerTest(@Autowired val restTemplate: TestRestTemplate) {
         )
         businessAppConfiguration = BusinessAppConfiguration(
             applicationName = MarcheSecuriseService.name,
+            originAppName = "Marchés Sécurisés",
             baseUrl = "http://localhost:8089",
             organizationSiret = siret,
             instanceId = "pa",

--- a/src/test/kotlin/org/ozwillo/dcimporter/service/MarcheSecuriseListingServiceTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/service/MarcheSecuriseListingServiceTest.kt
@@ -190,7 +190,7 @@ class MarcheSecuriseListingServiceTest(@Autowired val marcheSecuriseListingServi
         )
         val businessAppConfiguration = BusinessAppConfiguration(
             applicationName = MarcheSecuriseService.name,
-            originAppName = "Marchés Sécurisés",
+            displayName = "Marchés Sécurisés",
             baseUrl = "http://localhost:8089",
             organizationSiret = DCReturnModel.siret,
             login = "login",

--- a/src/test/kotlin/org/ozwillo/dcimporter/service/MarcheSecuriseListingServiceTest.kt
+++ b/src/test/kotlin/org/ozwillo/dcimporter/service/MarcheSecuriseListingServiceTest.kt
@@ -190,6 +190,7 @@ class MarcheSecuriseListingServiceTest(@Autowired val marcheSecuriseListingServi
         )
         val businessAppConfiguration = BusinessAppConfiguration(
             applicationName = MarcheSecuriseService.name,
+            originAppName = "Marchés Sécurisés",
             baseUrl = "http://localhost:8089",
             organizationSiret = DCReturnModel.siret,
             login = "login",


### PR DESCRIPTION
BREAKING CHANGE: now BusinessAppConfiguration documents must have a "originAppName" fields initialized in db.
In case of merging commit 380e65391e5942f5b708898a3d4283da312e9238 originAppName must be added to cloning function
Now Connector management view display real application name in table

improvement issue #5389